### PR TITLE
Radar hotfix: restrict radar to air vehicles and detect vehicles only

### DIFF
--- a/Air_Radar_Hot_Fix_March_2026.ts
+++ b/Air_Radar_Hot_Fix_March_2026.ts
@@ -1,3 +1,54 @@
+/**
+ * -------------------------------------------------------------------------
+ * Airsup_v1_34 Radar Hotfix
+ * -------------------------------------------------------------------------
+ * Date: 2026
+ * Authors: LongLiveBF4 (@iamnotdrell)
+ *
+ * Description:
+ * This hotfix modifies the radar system to improve gameplay behavior
+ * and reduce radar clutter.
+ *
+ * Changes Implemented:
+ *
+ * 1. Radar Creation Restriction
+ *    - Radar UI is now created ONLY when a player enters an air vehicle.
+ *    - Radar is removed when the player exits the air vehicle.
+ *    - Prevents radar from appearing while on foot or in ground vehicles.
+ *
+ * 2. Radar Detection Filtering
+ *    - Radar now detects ONLY vehicles.
+ *    - Infantry players are ignored.
+ *    - This reduces visual noise and improves radar relevance.
+ *
+ * 3. Radar Update Safety Check
+ *    - Radar update logic now runs only while the player is inside
+ *      a supported air vehicle.
+ *    - Prevents unnecessary calculations when radar should not be active.
+ *
+ * Files / Functions Modified:
+ *
+ *    initializePlayerState()
+ *        - Removed automatic radar creation.
+ *
+ *    OnPlayerEnterVehicle()
+ *        - Added radar creation for supported air vehicles.
+ *
+ *    OnPlayerExitVehicle()
+ *        - Added radar destruction when leaving air vehicles.
+ *
+ *    updateRadar()
+ *        - Added vehicle-only detection filter.
+ *        - Added safety check to ensure radar runs only in aircraft.
+ *
+ * Notes:
+ * - Radar UI layout and rendering logic were not modified.
+ * - Radar math and positioning remain unchanged.
+ * - This change focuses only on activation conditions and target filtering.
+ * - Portions of this hotfix were developed with the assistance of a
+ *   generative AI coding assistant (ChatGPT, based on OpenAI GPT-5.3).
+ */
+
 function initializePlayerState(player: mod.Player) {
 
     // Initialize scoreboard stats


### PR DESCRIPTION
Changes:
- Radar now activates only when player enters air vehicles
- Radar detection filters to vehicles only
- Infantry are no longer displayed on radar

Purpose:
Reduces radar clutter and aligns radar behavior with intended gameplay.